### PR TITLE
Added timestamp for last update to detect stucked AOC Informations

### DIFF
--- a/proxy-plugin/src/IantAocBilling.cpp
+++ b/proxy-plugin/src/IantAocBilling.cpp
@@ -188,7 +188,8 @@ void IantAocBilling::insertDataToMongoDb(const UtlString& callId, const UtlStrin
 		if(oldAmount<newAmount)
 		{
 			OS_LOG_DEBUG(FAC_SIP, "IAB: insertDataToMongoDb: Valid Amount ");
-			mongo::BSONObj data = BSON("_id" << callId.str() << "amount" << amount.str());
+			time_t ct = time(0);
+			mongo::BSONObj data = BSON("_id" << callId.str() << "amount" << amount.str() << "lastupdate" << ctime(&ct));
 			dbc->update(NAMESPACE_IANT_BILLING + "." + COLLECTION_IANT_BILLING, query, data, true);
 		}
 		else


### PR DESCRIPTION
If the CDR is not generated there is a stucked AOC in the MongoDB
With this Timestamp it is possible to detect this AOC Information (call longer than a day is unusual) so a following Server can handle this problem
